### PR TITLE
Fix Mac x86 download link

### DIFF
--- a/radarr/installation.md
+++ b/radarr/installation.md
@@ -81,7 +81,7 @@ It's therefore advisable to install Radarr as a system tray application if the u
 > Radarr is not compatible with OSX versions < 10.15 (Catalina) due to .NET incompatibilities.
 {.is-warning}
 
-1. Download the [MacOS App](https://radarr.servarr.com/v1/master/develop/updatefile?os=osx&runtime=netcore&arch=x64&installer=true) or  the [MacOS M1 App](https://radarr.servarr.com/v1/update/master/updatefile?os=osx&runtime=netcore&arch=arm64&installer=true) depending on your system
+1. Download the [MacOS App](https://radarr.servarr.com/v1/update/master/updatefile?os=osx&runtime=netcore&arch=x64&installer=true) or  the [MacOS M1 App](https://radarr.servarr.com/v1/update/master/updatefile?os=osx&runtime=netcore&arch=arm64&installer=true) depending on your system
 1. Open the archive and drag the Radarr icon to your Application folder.
 1. Self-sign Radarr `codesign --force --deep -s - Radarr.app`
 1. Browse to <http://localhost:7878> to start using Radarr


### PR DESCRIPTION
The link to download the x86 version of the Mac app is broken under the installation guide.