### PR TITLE
Mount DBs as Read-Only When Running pgloader via Docker

### DIFF
--- a/lidarr/postgres-setup.md
+++ b/lidarr/postgres-setup.md
@@ -102,7 +102,7 @@ DELETE FROM "MetadataProfiles";
       ```
 
     - ```bash
-      docker run --rm -v /absolute/path/to/lidarr.db:/lidarr.db --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /lidarr.db "postgresql://qstick:qstick@localhost/lidarr-main"
+      docker run --rm -v /absolute/path/to/lidarr.db:/lidarr.db:ro --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /lidarr.db "postgresql://qstick:qstick@localhost/lidarr-main"
       ```
 
   > If you experiance an error using pgloader it could be due to your DB being too large, to resolve this try adding `--with "prefetch rows = 100" --with "batch size = 1MB"` to the above command

--- a/prowlarr/postgres-setup.md
+++ b/prowlarr/postgres-setup.md
@@ -91,7 +91,7 @@ Before starting a migration please ensure that you have run Prowlarr against the
       ```
 
     - ```bash
-      docker run --rm -v /absolute/path/to/prowlarr.db:/prowlarr.db --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /prowlarr.db "postgresql://qstick:qstick@localhost/prowlarr-main"
+      docker run --rm -v /absolute/path/to/prowlarr.db:/prowlarr.db:ro --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /prowlarr.db "postgresql://qstick:qstick@localhost/prowlarr-main"
       ```
 
   > If you experiance an error using pgloader it could be due to your DB being too large, to resolve this try adding `--with "prefetch rows = 100" --with "batch size = 1MB"` to the above command

--- a/radarr/postgres-setup.md
+++ b/radarr/postgres-setup.md
@@ -101,7 +101,7 @@ DELETE FROM "Metadata";
       ```
 
     - ```bash
-      docker run --rm -v /absolute/path/to/radarr.db:/radarr.db --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /radarr.db "postgresql://qstick:qstick@localhost/radarr-main"
+      docker run --rm -v /absolute/path/to/radarr.db:/radarr.db:ro --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /radarr.db "postgresql://qstick:qstick@localhost/radarr-main"
       ```
 
   > If you experiance an error using pgloader it could be due to your DB being too large, to resolve this try adding `--with "prefetch rows = 100" --with "batch size = 1MB"` to the above command

--- a/readarr/postgres-setup.md
+++ b/readarr/postgres-setup.md
@@ -103,7 +103,7 @@ DELETE FROM "MetadataProfiles";
       ```
 
     - ```bash
-      docker run --rm -v /absolute/path/to/readarr.db:/readarr.db --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /readarr.db "postgresql://qstick:qstick@localhost/readarr-main"
+      docker run --rm -v /absolute/path/to/readarr.db:/readarr.db:ro --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /readarr.db "postgresql://qstick:qstick@localhost/readarr-main"
       ```
 
 > If you experiance an error using pgloader it could be due to your DB being too large, to resolve this try adding `--with "prefetch rows = 100" --with "batch size = 1MB"` to the above command {.is-warning}

--- a/whisparr/postgres-setup.md
+++ b/whisparr/postgres-setup.md
@@ -97,7 +97,7 @@ DELETE FROM "DelayProfiles"
       ```
 
     - ```bash
-      docker run --rm -v /absolute/path/to/whisparr.db:/whisparr.db --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /whisparr.db "postgresql://qstick:qstick@localhost/whisparr-main"
+      docker run --rm -v /absolute/path/to/whisparr.db:/whisparr.db:ro --network=host ghcr.io/roxedus/pgloader --with "quote identifiers" --with "data only" /whisparr.db "postgresql://qstick:qstick@localhost/whisparr-main"
       ```
 
 > With these handled, it is pretty straightforward after telling it to not mess with the scheme using `--with "data only"`


### PR DESCRIPTION
This PR changes the `docker run` commands for `pgloader` to mount the `.db` file as read-only but adding `:ro` to the volume argument.