### PR TITLE
Clarify instructions for running multiple Radarr instances

### DIFF
--- a/radarr/installation.md
+++ b/radarr/installation.md
@@ -588,11 +588,13 @@ separate locations. {.is-warning}
 #### Prerequisites (Tray App)
 
 - [You must have Radarr already installed](#windows)
-- Radarr must be configured with a `/data=` argument to allow multiple instances
+- Radarr's shortcut must be configured with a `/data=` argument in the 'target' field to allow multiple instances
 - Navigate to the Startup Folder for the current user `%appdata%\Microsoft\Windows\Start Menu\Programs\Startup` and edit the existing shortcut if needed.
 
 #### Creating Radarr-4K Tray App
 
+- Create a new folder for Radarr-4K's configuration files. Most use a similar place such as 
+    `C:\ProgramData\Radarr-4K`
 - Right click and Create New Shortcut
 - Path: `C:\ProgramData\Radarr\bin\Radarr.exe /data=C:\ProgramData\Radarr-4K`
 - Give the shortcut a unique name such as `Radarr-4K` and finish the wizard.

--- a/radarr/installation.md
+++ b/radarr/installation.md
@@ -534,6 +534,9 @@ The following requirements should be noted:
 
 This guide will show you how to run multiple instances of Radarr on Windows using only one base installation. This guide was put together using Windows 10; if you are using a previous version of Windows (7, 8, etc.) you may need to adjust some things. This guide also assumes that you have installed Radarr to the default directory, and your second instance of Radarr will be called Radarr-4K. Feel free to change things to fit your own installations, though.
 
+> Note: You should run Radarr as **either** a [tray app](#tray-app-windows) or [as a service](#service-windows). Running an app and a service is unnecessary and likely to cause issues.
+
+
 ### Service (Windows)
 
 #### Prerequisites (Service)

--- a/radarr/installation.md
+++ b/radarr/installation.md
@@ -534,7 +534,7 @@ The following requirements should be noted:
 
 This guide will show you how to run multiple instances of Radarr on Windows using only one base installation. This guide was put together using Windows 10; if you are using a previous version of Windows (7, 8, etc.) you may need to adjust some things. This guide also assumes that you have installed Radarr to the default directory, and your second instance of Radarr will be called Radarr-4K. Feel free to change things to fit your own installations, though.
 
-> Note: You should run Radarr as **either** a [tray app](#tray-app-windows) or [as a service](#service-windows). Running an app and a service is unnecessary and likely to cause issues.
+> Note: You should run Radarr as **either** [a service](#service-windows) or as a [tray app](#tray-app-windows). Running an app and a service is unnecessary and likely to cause issues.
 
 
 ### Service (Windows)

--- a/radarr/installation.md
+++ b/radarr/installation.md
@@ -534,7 +534,7 @@ The following requirements should be noted:
 
 This guide will show you how to run multiple instances of Radarr on Windows using only one base installation. This guide was put together using Windows 10; if you are using a previous version of Windows (7, 8, etc.) you may need to adjust some things. This guide also assumes that you have installed Radarr to the default directory, and your second instance of Radarr will be called Radarr-4K. Feel free to change things to fit your own installations, though.
 
-> Note: You should run Radarr as **either** [a service](#service-windows) or as a [tray app](#tray-app-windows). Running an app and a service is unnecessary and likely to cause issues.
+> Note: You should run Radarr as **either** [a service](#service-windows) or as a [tray app](#tray-app-windows). Running both an app and a service is unnecessary and likely to cause issues.
 
 
 ### Service (Windows)


### PR DESCRIPTION
Based on user feedback, the instructions for setting up multiple Radarr instances could be confusing for certain users. 

This PR clarifies the need to create a second configuration folder for a second tray app instance, is slightly more specific on how to define the `data` argument, and adds a note about not running both a tray app and a service, including links to the relevant sections. 