### PR TITLE
add(ux): adds options and parsing for variables

### DIFF
--- a/servarr/servarr-uninstall-script.sh
+++ b/servarr/servarr-uninstall-script.sh
@@ -25,28 +25,48 @@ fi
 
 #!/bin/bash
 
-# Default application name; override by setting APP_NAME environment variable
-app="${APP_NAME:-}"
+# Default application name; override by enter manually
+select app in "lidarr" "prowlarr" "radarr" "readarr" "whisparr" "manual" "quit "; do
 
-if [ -z "$app" ]; then
-    echo "Please set the app name via the APP_NAME environment variable."
-    exit 1
-fi
+    case $app in
+        manual)
+                read -p "Enter the service name manually: " manual_app
+                app="$manual_app"
+                break
+                ;;
+        quit)
+            exit 0
+            ;;
+        *)
+        echo "You selected: $app"
+        break
+        esac
+    done
 
 # Extract paths and user/group from systemd service file
 ExecStart=$(systemctl show -p ExecStart --value "$app.service")
+
+echo "$ExecStart"
+if [ -z "$ExecStart" ]; then
+    echo "Error: Failed to find matching service name. Aborting."
+    exit 1
+fi
+
 User=$(systemctl show -p User --value "$app.service")
 Group=$(systemctl show -p Group --value "$app.service")
-bindir=$(echo "$ExecStart" | grep -oP '(?<=ExecStart=)/[^ ]+(?=/[^/ ]+ )' | head -1)
-appdataenvname="${app^^}_DATA_DIR" # Convert app name to uppercase for environment variable
-appdatadir=${!appdataenvname:-$(echo "$ExecStart" | grep -oP '(?<=-data=)[^ ]*')}
+bindir=$(echo "$ExecStart" | awk -F ' ' '{ for(i=1; i<=NF; i++) { if ($i ~ /path=/) { split($i, path, "="); print path[2]; } } }')
+appdatadir=$(echo "$ExecStart" | awk -F ' ' '{ for(i=1; i<=NF; i++) { if ($i ~ /-data=/) { split($i, data, "="); print data[2]; } } }')
+
+read -e -p "Found data directory to be '$appdatadir'. Do you want to change this? (press Enter to accept): " userdatadir
+
+# If variable is empty, use parsed value
+if [ -n "$userdatadir" ]; then
+    appdatadir=$userdatadir
+fi
 
 echo "Installation directory (bindir): $bindir"
 echo "Data directory (appdatadir): $appdatadir"
 echo "Running as User: $User, Group: $Group"
-
-# Inform user how to override data directory with an environment variable
-echo "To override the data directory, set the $appdataenvname environment variable."
 
 # Instructions for user and group removal
 echo "To remove the user and/or group, use: sudo userdel $User; sudo groupdel $Group"


### PR DESCRIPTION
uses the options method from the install script to select service name

parses the bindir (path) and appdatadir (data parameter) from the execstart line. 

prompts the user for changing the parsed/default variables

tested to work on ubuntu 22.04.1 with install script radarr installation