### PR TITLE
Adding instructions for setting X-Forwarded-Host on non-standard ports

### DIFF
--- a/prowlarr/installation/reverse-proxy.md
+++ b/prowlarr/installation/reverse-proxy.md
@@ -19,7 +19,7 @@ Sample config examples for configuring Prowlarr to be accessible through a rever
 
 Add the following configuration to `nginx.conf` located in the root of your Nginx configuration. The code block should be added inside the `server context`. [Full example of a typical Nginx configuration](https://www.nginx.com/resources/wiki/start/topics/examples/full/)
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` as well as `proxy_set_header X-Forwarded-Host $host:$server_port` or `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 location /prowlarr {


### PR DESCRIPTION
When using non-standard ports, download links are missing the port number unless X-Forwarded-Host includes the port number, causing incorrect download links to be provided by Prowlarr. Users may use non-standard ports if exposing instances externally with ISPs that do not allow listening on 80/443 or self-hosting in unprivileged LXC containers which are denied access to ports 80/443