### PR TITLE
Add 'Ignored Users' step to Allquiet Slskd plug-in Indexer section

### DIFF
--- a/lidarr/plugins.md
+++ b/lidarr/plugins.md
@@ -77,7 +77,8 @@ Once the plugin is installed, Slskd can be added as a download client.
 To search, Slskd must also be added as an Indexer. 
 - Navigate to `/settings/indexers`, and select the <kb>+</kb> button under Indexers. Slskd will appear at the bottom under the Other section.
 - Enter the correct URL.
-- Enter the API key
+- Enter the API key.
+- Enter a '0' (Key) and your Soulseek username (Value) for 'Ignored Users'.
 - Select the Test button.
   - The Indexer test will send a test search to slskd for "Silent Partner Chances".
 - If the Test returns a green checkmark, select Save.


### PR DESCRIPTION
Added point instructing users to fill out 'Ignored Users' field under the _Indexer_ section for the Allquiet Soulseek plugin. Also added a period to the previous point in the list for consistency.

Fixes allquiet-hub/Lidarr.Plugin.Slskd#3