### PR TITLE
readarr: specify supported NodeJS version

### DIFF
--- a/readarr/contributing.md
+++ b/readarr/contributing.md
@@ -30,12 +30,10 @@ Readarr is written in C# (backend) and JS (frontend). The backend is built on th
 - HTML/Javascript editor of choice (VS Code/Sublime Text/Webstorm/Atom/etc)
 - [Git](https://git-scm.com/downloads)
 - The [Node.js](https://nodejs.org/) runtime is required. The following versions are supported:
-  - **12.0** or later
-  - **14.0** or later
-  - **16.0** or later
+  - **20.0**
 {.grid-list}
 
-> Readarr will **NOT** run on older versions such as `10.x`, `8.x`, `6.x`, or any version below 12.0!
+> Readarr will **NOT** run on older versions such as `18.x`, `16.x` or any version below 20.0! Due to a dependency issue, it will also not run on `21.x` and is untested on other verisons.
 {.is-warning}
 
 - [Yarn](https://yarnpkg.com/getting-started/install) is required to build the frontend

--- a/readarr/contributing.md
+++ b/readarr/contributing.md
@@ -30,7 +30,7 @@ Readarr is written in C# (backend) and JS (frontend). The backend is built on th
 - HTML/Javascript editor of choice (VS Code/Sublime Text/Webstorm/Atom/etc)
 - [Git](https://git-scm.com/downloads)
 - The [Node.js](https://nodejs.org/) runtime is required. The following versions are supported:
-  - **20.0**
+  - **20** (any minor or patch version within this)
 {.grid-list}
 
 > Readarr will **NOT** run on older versions such as `18.x`, `16.x` or any version below 20.0! Due to a dependency issue, it will also not run on `21.x` and is untested on other verisons.


### PR DESCRIPTION
Due to a dependency issue with `rimraf` the frontend will not build unless we are using node version 20 OR 22+. However, given that we haven't explicitly tested on node 22, and version 20 is supported by Sonarr currently, the only suggested version is node 20.

References:  
- https://github.com/Sonarr/Sonarr/blob/v5-develop/package.json#L152
- https://github.com/Sonarr/Sonarr/commit/c6071f6d81a968d3ed7c6bf4bae035961b54d128