### PR TITLE
fix colors in version print statement in servarr-install-script.sh

### DIFF
--- a/servarr/servarr-install-script.sh
+++ b/servarr/servarr-install-script.sh
@@ -64,7 +64,7 @@ echo -e "#                                                           #"
 echo -e "#############################################################"
 echo -e ${reset}
 
-echo "Running Servarr Install Script - Version ${brown}[$scriptversion]${reset} as of ${brown}[$scriptdate]${reset}"
+echo -e "Running Servarr Install Script - Version ${brown}[$scriptversion]${reset} as of ${brown}[$scriptdate]${reset}"
 echo ""
 echo "Select the application to install: "
 echo ""


### PR DESCRIPTION
Minor fix to server version print statement so that colors show up properly during install script.

Before:
```
#############################################################
#                                                           #
#   Welcome to the Servarr Community Installation Script!   #
#                                                           #
#  This script is for any Debian-based distro users         #
#  who need a little help with just the press of a button.  #
#  If you have not done so, exit the script and read the    #
#  Boilerplate Warning just to CYA. Enjoy your new setup!   #
#                                                           #
#############################################################

Running Servarr Install Script - Version \033[0;33m[3.1.14]\033[0m as of \033[0;33m[2024-12-07]\033[0m

Select the application to install:

1) lidarr
2) prowlarr
3) radarr
4) readarr
5) whisparr
6) whisparr-v3
7) quit
#?
```

After:

```
#############################################################
#                                                           #
#   Welcome to the Servarr Community Installation Script!   #
#                                                           #
#  This script is for any Debian-based distro users         #
#  who need a little help with just the press of a button.  #
#  If you have not done so, exit the script and read the    #
#  Boilerplate Warning just to CYA. Enjoy your new setup!   #
#                                                           #
#############################################################

Running Servarr Install Script - Version [3.1.14] as of [2024-12-07]

Select the application to install:

1) lidarr
2) prowlarr
3) radarr
4) readarr
5) whisparr
6) whisparr-v3
7) quit
#?
```