### PR TITLE
update instructions to reset password

### DIFF
--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -526,12 +526,12 @@ To disable authentication (to reset your forgotten username or password) you wil
 
 1. Stop Lidarr
 1. Open config.xml in a text editor
-1. Find the authentication method line will be
+1. Find the authentication method line - will be
 `<AuthenticationMethod>Basic</AuthenticationMethod>` or `<AuthenticationMethod>Forms</AuthenticationMethod>`
-*(Be sure you do not have two AuthenticationMethod entries in your file!)*
-1. Change the `AuthenticationMethod` line to `<AuthenticationMethod>None</AuthenticationMethod>`
-1. Restart Lidarr
-1. Lidarr will now be accessible without a password, you should go the `Settings: General` in the UI and set your username and password
+***(Be sure you do not have two AuthenticationMethod entries in your file!)***
+1. Remove the entire `AuthenticationMethod` line
+1. Start Lidarr
+1. Lidarr will now be accessible without a password. When you open the Web UI, you should be prompted to set a new password and authentication method
 
 ## How do I stop the browser from launching on startup
 

--- a/prowlarr/faq.md
+++ b/prowlarr/faq.md
@@ -478,14 +478,14 @@ If your download client and Prowlarr are on the same machine there is no reason 
 
 {#help-i-have-forgotten-my-password}
 
-1. Close Prowlarr
+1. Stop Prowlarr
 1. Open config.xml in a text editor
-1. Find the authentication method line will be
+1. Find the authentication method line - will be
 `<AuthenticationMethod>Basic</AuthenticationMethod>` or `<AuthenticationMethod>Forms</AuthenticationMethod>`
-***(Be sure that you do not have two AuthenticationMethod entries in your file)***
-1. Change the `AuthenticationMethod` line to `<AuthenticationMethod>External</AuthenticationMethod>`
-1. Restart Prowlarr
-1. Prowlarr will now be accessible without a password, you should go the `Settings` => `General` in the UI, change the Authentication Method to Forms and set your new username and password
+***(Be sure you do not have two AuthenticationMethod entries in your file!)***
+1. Remove the entire `AuthenticationMethod` line
+1. Start Prowlarr
+1. Prowlarr will now be accessible without a password. When you open the Web UI, you should be prompted to set a new password and authentication method
 
 ## Weird UI Issues
 

--- a/radarr/faq.md
+++ b/radarr/faq.md
@@ -537,14 +537,14 @@ After creating the symlink, restart Radarr. It will now use the system's SQLite 
 
 To disable authentication (to reset your forgotten username or password) you will need need to edit `config.xml` which will be inside the [Radarr Appdata Directory](/radarr/appdata-directory)
 
-1. Close Radarr
+1. Stop Radarr
 1. Open config.xml in a text editor
-1. Find the authentication method line will be
+1. Find the authentication method line - will be
 `<AuthenticationMethod>Basic</AuthenticationMethod>` or `<AuthenticationMethod>Forms</AuthenticationMethod>`
-***(Be sure that you do not have two AuthenticationMethod entries in your file)***
-1. Change the `AuthenticationMethod` line to `<AuthenticationMethod>External</AuthenticationMethod>`
-1. Restart Radarr
-1. Radarr will now be accessible without a password, you should go the `Settings` => `General` in the UI, change the Authentication Method to Basic or Forms and set your new username and password
+***(Be sure you do not have two AuthenticationMethod entries in your file!)***
+1. Remove the entire `AuthenticationMethod` line
+1. Start Radarr
+1. Radarr will now be accessible without a password. When you open the Web UI, you should be prompted to set a new password and authentication method
 
 ## How do I stop the browser from launching on startup
 

--- a/readarr/faq.md
+++ b/readarr/faq.md
@@ -406,14 +406,14 @@ chmod -R 0644 *
 
 To disable authentication (to reset your forgotten username or password) you will need need to edit `config.xml` which will be inside the [Readarr Appdata Directory](/readarr/appdata-directory)
 
-1. Close Readarr
+1. Stop Readarr
 1. Open config.xml in a text editor
-1. Find the authentication method line will be
+1. Find the authentication method line - will be
 `<AuthenticationMethod>Basic</AuthenticationMethod>` or `<AuthenticationMethod>Forms</AuthenticationMethod>`
-*(Be sure that you do not have two AuthenticationMethod entries in your file)*
-1. Change the `AuthenticationMethod` line to `<AuthenticationMethod>External</AuthenticationMethod>`
-1. Restart Readarr
-1. Readarr will now be accessible without a password, you should go the `Settings: General` in the UI and set your username and password
+***(Be sure you do not have two AuthenticationMethod entries in your file!)***
+1. Remove the entire `AuthenticationMethod` line
+1. Start Readarr
+1. Readarr will now be accessible without a password. When you open the Web UI, you should be prompted to set a new password and authentication method
 
 ## How do I stop the browser from launching on startup
 

--- a/sonarr/faq.md
+++ b/sonarr/faq.md
@@ -151,13 +151,12 @@ To disable authentication (to reset your forgotten username or password) you wil
 
 1. Stop Sonarr
 1. Open config.xml in a text editor
-1. Find the authentication method line will be
+1. Find the authentication method line - will be
 `<AuthenticationMethod>Basic</AuthenticationMethod>` or `<AuthenticationMethod>Forms</AuthenticationMethod>`
 ***(Be sure that you do not have two AuthenticationMethod entries in your file)***
-1. Change the `AuthenticationMethod` line to `<AuthenticationMethod>External</AuthenticationMethod>`
-***(If you are running an old v3 version, the correct value is `None` instead of `External`)***
+1. Remove the entire `AuthenticationMethod` line
 1. Restart Sonarr
-1. Sonarr will now be accessible without a password, you should go the `Settings: General` in the UI and set your username and password
+1. Sonarr will now be accessible without a password. When you open the Web UI, you should be prompted to set a new password and authentication method
 
 ## Why are there two files? \| Why is there a file left in downloads
 

--- a/whisparr/faq.md
+++ b/whisparr/faq.md
@@ -417,12 +417,14 @@ dateCreated: 2022-04-03T03:49:19.500Z
 
 To disable authentication (to reset your forgotten username or password) you will need need to edit `config.xml` which will be inside the [Whisparr Appdata Directory](/whisparr/appdata-directory)
 
+1. Stop Whisparr
 1. Open config.xml in a text editor
-1. Find the authentication method line will be
+1. Find the authentication method line - will be
 `<AuthenticationMethod>Basic</AuthenticationMethod>` or `<AuthenticationMethod>Forms</AuthenticationMethod>`
-1. Change the `AuthenticationMethod` line to `<AuthenticationMethod>None</AuthenticationMethod>`
-1. Restart Whisparr
-1. Whisparr will now be accessible without a password, you should go the `Settings: General` in the UI and set your username and password
+***(Be sure you do not have two AuthenticationMethod entries in your file!)***
+1. Remove the entire `AuthenticationMethod` line
+1. Start Whisparr
+1. Whisparr will now be accessible without a password. When you open the Web UI, you should be prompted to set a new password and authentication method
 
 ## How do I stop the browser from launching on startup
 


### PR DESCRIPTION
updates the instructions to reset passwords to match the method listed in the Servarr discord bot's instructions.

doing it this way means that the user is prompted to reset the password, instead of simply being let in without setting a new password