### PR TITLE
Radarr: Add {MediaInfo BestAudioCodec} token to naming docs

### DIFF
--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -172,7 +172,7 @@ As of Lidarr v2, Authentication is Mandatory.
 ## How can I find a MusicBrainz ID?
 
 1. [Search for your desired artist or album](https://musicbrainz.org/search) (use `Release Group` type for albums)
-2. The MusicBrainz ID can be found under the "Details" tab: 
+2. The MusicBrainz ID can be found under the "Details" tab:
 ![musicbrainz_id_detail_tab.png](/images/musicbrainz_id_detail_tab.png)
 3. Or at the end of the URL:
 ![musicbrainz_id_url.png](/images/musicbrainz_id_url.png)

--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -169,14 +169,13 @@ As of Lidarr v2, Authentication is Mandatory.
 
 - Artists that do not show up in search may be added by searching for `lidarr:mbid` where `mbid` is the Musicbrainz ID of the artist.
 
-## How can I find a MusicBrainz ID?
+## How can I find a MusicBrainz ID
 
 1. [Search for your desired artist or album](https://musicbrainz.org/search) (use `Release Group` type for albums)
 2. The MusicBrainz ID can be found under the "Details" tab:
 ![musicbrainz_id_detail_tab.png](/images/musicbrainz_id_detail_tab.png)
 3. Or at the end of the URL:
 ![musicbrainz_id_url.png](/images/musicbrainz_id_url.png)
-
 
 ## Lidarr matched an album with too many tracks. How can I change the Album to the correct Release
 

--- a/radarr/settings.md
+++ b/radarr/settings.md
@@ -211,6 +211,7 @@ Also, note that for each individual settings page, there are some options at the
 - `{MediaInfo Simple}` = x264 DTS
 - `{MediaInfo Full}` = x264 DTS \[EN+DE\]
 - `{MediaInfo AudioCodec}` = DTS
+- `{MediaInfo BestAudioCodec}` = DTS-HD MA
 - `{MediaInfo AudioChannels}` = 5.1
 - `{MediaInfo AudioLanguages}` = \[EN+DE\]
 - `{MediaInfo SubtitleLanguages}` = \[EN\]


### PR DESCRIPTION
Documents the new `{MediaInfo BestAudioCodec}` naming token added in Radarr/Radarr#11386.

This token resolves to the highest quality audio codec across all streams in a file (e.g. DTS-HD MA), as opposed to `{MediaInfo AudioCodec}` which uses the primary (first) stream.