### PR TITLE
Fix in powershell code for creating folders and moving files to folders

### DIFF
--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -172,7 +172,7 @@ As of Lidarr v2, Authentication is Mandatory.
 ## How can I find a MusicBrainz ID?
 
 1. [Search for your desired artist or album](https://musicbrainz.org/search) (use `Release Group` type for albums)
-2. The MusicBrainz ID can be found under the "Details" tab: 
+2. The MusicBrainz ID can be found under the "Details" tab:
 ![musicbrainz_id_detail_tab.png](/images/musicbrainz_id_detail_tab.png)
 3. Or at the end of the URL:
 ![musicbrainz_id_url.png](/images/musicbrainz_id_url.png)

--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -169,14 +169,13 @@ As of Lidarr v2, Authentication is Mandatory.
 
 - Artists that do not show up in search may be added by searching for `lidarr:mbid` where `mbid` is the Musicbrainz ID of the artist.
 
-## How can I find a MusicBrainz ID?
+## How can I find a MusicBrainz ID
 
 1. [Search for your desired artist or album](https://musicbrainz.org/search) (use `Release Group` type for albums)
 2. The MusicBrainz ID can be found under the "Details" tab:
 ![musicbrainz_id_detail_tab.png](/images/musicbrainz_id_detail_tab.png)
 3. Or at the end of the URL:
 ![musicbrainz_id_url.png](/images/musicbrainz_id_url.png)
-
 
 ## Lidarr matched an album with too many tracks. How can I change the Album to the correct Release
 

--- a/radarr/tips-and-tricks.md
+++ b/radarr/tips-and-tricks.md
@@ -86,11 +86,8 @@ If you need to clean up empty directories, this command will do that:
 Alternatively in Windows you can run the following script in Powershell to iterate over each file in a directory, and move it to a folder with the same name.
 
 ```powershell
-Get-ChildItem -File
-  | ForEach-Object {
-    $dir = New-Item -ItemType Directory -Name $_.BaseName -Force
-    $_ | Move-Item -Destination $dir
-  }
+Get-ChildItem -File | ForEach-Object {$dir = New-Item -ItemType Directory -Name $_.BaseName -Force 
+$_ | Move-Item -Destination $dir}
 ```
 
 # Configuring Radarr to Auto-Remove Completed Torrents

--- a/radarr/tips-and-tricks.md
+++ b/radarr/tips-and-tricks.md
@@ -86,7 +86,7 @@ If you need to clean up empty directories, this command will do that:
 Alternatively in Windows you can run the following script in Powershell to iterate over each file in a directory, and move it to a folder with the same name.
 
 ```powershell
-Get-ChildItem -File | ForEach-Object {$dir = New-Item -ItemType Directory -Name $_.BaseName -Force 
+Get-ChildItem -File | ForEach-Object {$dir = New-Item -ItemType Directory -Name $_.BaseName -Force
 $_ | Move-Item -Destination $dir}
 ```
 


### PR DESCRIPTION
Fixed the powershell code for creating folders for separate files and moving the files to those new folders. The old code did not work due to incorrect formatting.