### PR TITLE
Fixed: Update Lidarr download rank for custom formats

### DIFF
--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -172,7 +172,7 @@ As of Lidarr v2, Authentication is Mandatory.
 ## How can I find a MusicBrainz ID?
 
 1. [Search for your desired artist or album](https://musicbrainz.org/search) (use `Release Group` type for albums)
-2. The MusicBrainz ID can be found under the "Details" tab: 
+2. The MusicBrainz ID can be found under the "Details" tab:
 ![musicbrainz_id_detail_tab.png](/images/musicbrainz_id_detail_tab.png)
 3. Or at the end of the URL:
 ![musicbrainz_id_url.png](/images/musicbrainz_id_url.png)

--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -169,14 +169,13 @@ As of Lidarr v2, Authentication is Mandatory.
 
 - Artists that do not show up in search may be added by searching for `lidarr:mbid` where `mbid` is the Musicbrainz ID of the artist.
 
-## How can I find a MusicBrainz ID?
+## How can I find a MusicBrainz ID
 
 1. [Search for your desired artist or album](https://musicbrainz.org/search) (use `Release Group` type for albums)
 2. The MusicBrainz ID can be found under the "Details" tab:
 ![musicbrainz_id_detail_tab.png](/images/musicbrainz_id_detail_tab.png)
 3. Or at the end of the URL:
 ![musicbrainz_id_url.png](/images/musicbrainz_id_url.png)
-
 
 ## Lidarr matched an album with too many tracks. How can I change the Album to the correct Release
 

--- a/lidarr/faq.md
+++ b/lidarr/faq.md
@@ -124,10 +124,10 @@ As of Lidarr v2, Authentication is Mandatory.
 
 - The current logic [can be found here](https://github.com/Lidarr/Lidarr/blob/develop/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs).
 
-- As of 2022-01-23 the logic is as follows:
+- As of 2023-01-22 the logic is as follows:
 
 1. Quality
-1. Preferred Word Score
+1. Custom Format Score
 1. Protocol (as configured in the relevant Delay Profile)
 1. Indexer Priority
 1. Seeds/Peers (If Torrent)


### PR DESCRIPTION
Update the download rank list for Lidarr to specify 'Custom Format Score' instead of 'Preferred Word Score' and update the date based on when Custom Formats were added.