### PR TITLE
docs: fix reverse proxy guidance for non-standard ports

### DIFF
--- a/lidarr/installation/reverse-proxy.md
+++ b/lidarr/installation/reverse-proxy.md
@@ -9,7 +9,7 @@ Sample config examples for configuring Lidarr to be accessible through a reverse
 
 Add the following configuration to `nginx.conf` located in the root of your Nginx configuration. The code block should be added inside the `server context`. [Full example of a typical Nginx configuration](https://www.nginx.com/resources/wiki/start/topics/examples/full/)
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 location ^~ /lidarr {
@@ -52,7 +52,7 @@ Alternatively you can use a subdomain for lidarr. In this case you would visit `
 > Many free DNS providers do not support this {.is-warning}
 By default Nginx includes the `sites-enabled` folder. You can check this in `nginx.conf`, if not you can add it using the [include directive](http://nginx.org/en/docs/ngx_core_module.html#include). And really important, it has to be inside the `http context`. Now create a config file inside the sites-enabled folder and enter the following configuration.
 > For this configuration it is recommended to set baseurl to '' (empty). This configuration assumes you are using the default `8686` and Lidarr is accessible on the localhost (127.0.0.1). For this configuration the subdomain `lidarr` is chosen (line 5). {.is-info}
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 server {

--- a/prowlarr/installation/reverse-proxy.md
+++ b/prowlarr/installation/reverse-proxy.md
@@ -19,7 +19,7 @@ Sample config examples for configuring Prowlarr to be accessible through a rever
 
 Add the following configuration to `nginx.conf` located in the root of your Nginx configuration. The code block should be added inside the `server context`. [Full example of a typical Nginx configuration](https://www.nginx.com/resources/wiki/start/topics/examples/full/)
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` as well as `proxy_set_header X-Forwarded-Host $host:$server_port` or `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 location /prowlarr {

--- a/radarr/installation/reverse-proxy.md
+++ b/radarr/installation/reverse-proxy.md
@@ -19,7 +19,7 @@ Sample config examples for configuring Radarr to be accessible from the outside 
 
 Add the following configuration to `nginx.conf` located in the root of your Nginx configuration. The code block should be added inside the `server context`. [Full example of a typical Nginx configuration](https://www.nginx.com/resources/wiki/start/topics/examples/full/)
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 location ^~ /radarr {
@@ -65,7 +65,7 @@ By default Nginx includes the `sites-enabled` folder. You can check this in `ngi
 
 > For this configuration it is recommended to set baseurl to '' (empty). This configuration assumes you are using the default `7878` and Radarr is accessible on the localhost (127.0.0.1). For this configuration the subdomain `radarr` is chosen (line 5). {.is-info}
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 server {

--- a/readarr/installation/reverse-proxy.md
+++ b/readarr/installation/reverse-proxy.md
@@ -30,7 +30,7 @@ Sample config examples for configuring Readarr to be accessible from the outside
 
 Add the following configuration to `nginx.conf` located in the root of your Nginx configuration. The code block should be added inside the `server context`. [Full example of a typical Nginx configuration](https://www.nginx.com/resources/wiki/start/topics/examples/full/)
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 location ^~ /readarr {
@@ -76,7 +76,7 @@ By default Nginx includes the `sites-enabled` folder. You can check this in `ngi
 
 > For this configuration it is recommended to set baseurl to '' (empty). This configuration assumes you are using the default `8787` and Readarr is accessible on the localhost (127.0.0.1). For this configuration the subdomain `readarr` is chosen (line 5). {.is-info}
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 server {

--- a/sonarr/installation/reverse-proxy.md
+++ b/sonarr/installation/reverse-proxy.md
@@ -9,7 +9,7 @@ Sample config examples for configuring Sonarr to be accessible from the outside 
 
 Add the following configuration to `nginx.conf` located in the root of your Nginx configuration. The code block should be added inside the `server context`. [Full example of a typical Nginx configuration](https://www.nginx.com/resources/wiki/start/topics/examples/full/)
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 location ^~ /sonarr {
@@ -55,7 +55,7 @@ By default Nginx includes the `sites-enabled` folder. You can check this in `ngi
 
 > For this configuration it is recommended to set baseurl to '' (empty). This configuration assumes you are using the default `8989` and Sonarr is accessible on the localhost (127.0.0.1). For this configuration the subdomain `sonarr` is chosen (line 5). {.is-info}
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 server {

--- a/whisparr/installation/reverse-proxy.md
+++ b/whisparr/installation/reverse-proxy.md
@@ -9,7 +9,7 @@ Sample config examples for configuring Whisparr to be accessible from the outsid
 
 Add the following configuration to `nginx.conf` located in the root of your Nginx configuration. The code block should be added inside the `server context`. [Full example of a typical Nginx configuration](https://www.nginx.com/resources/wiki/start/topics/examples/full/)
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 location /whisparr {
@@ -55,7 +55,7 @@ By default Nginx includes the `sites-enabled` folder. You can check this in `ngi
 
 > For this configuration it is recommended to set baseurl to '' (empty). This configuration assumes you are using the default `6969` and Whisparr is accessible on the localhost (127.0.0.1). For this configuration the subdomain `whisparr` is chosen (line 5). {.is-info}
 
-> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $host:$server_port` or `proxy_set_header Host $http_host` {.is-warning}
+> If you're using a non-standard http/https server port, make sure your Host header also includes it, i.e.: `proxy_set_header Host $http_host` and also update `proxy_set_header X-Forwarded-Host $http_host` {.is-warning}
 
 ```nginx
 server {


### PR DESCRIPTION
## Summary

Updates the nginx non-standard port warning across all reverse proxy docs (Sonarr, Radarr, Lidarr, Readarr, Prowlarr, Whisparr). The previous advice only mentioned updating `proxy_set_header Host` but not `X-Forwarded-Host`, causing login redirects to use the wrong port.

## Changes

6 files updated. The warning now reads: use `proxy_set_header Host $http_host` **and also** `proxy_set_header X-Forwarded-Host $http_host`. Using `$http_host` is cleaner than `$host:$server_port` since it already includes the port.

Fixes #383

This contribution was developed with AI assistance (Claude Code).