### PR TITLE
Add Qui to Prowlarr supported applications

### DIFF
--- a/prowlarr/supported.md
+++ b/prowlarr/supported.md
@@ -24,6 +24,8 @@ Prowlarr can automatically sync indexers with various applications
   - [Refer to the Settings Page](/prowlarr/settings#applications)
 - Mylar {#mylar}
   - [Refer to the Settings Page](/prowlarr/settings#applications)
+- Qui {#qui}
+  - [Refer to the Settings Page](/prowlarr/settings#applications)
 - Radarr {#radarr}
   - [Refer to the Settings Page](/prowlarr/settings#applications)
 - Readarr {#readarr}


### PR DESCRIPTION
Adds [Qui](https://github.com/autobrr/qui) to the Prowlarr supported applications list in `prowlarr/supported.md`.

Qui is a qBittorrent web UI from the autobrr team that supports cross-seeding via Torznab indexers. The corresponding Prowlarr integration PR is at Prowlarr/Prowlarr#2657.

No changes to `settings.md` are needed since the applications section documents the generic configuration flow shared by all apps.