### PR TITLE
Add UniqueSingles plugin to Lidarr plugins list

### DIFF
--- a/lidarr/beets-integration.md
+++ b/lidarr/beets-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Lidarr and beets Integration
-description: 
+description:
 published: true
 date: 2026-05-03T15:10:07.217Z
 tags: lidarr, beets

--- a/lidarr/installation/reverse-proxy.md
+++ b/lidarr/installation/reverse-proxy.md
@@ -1,9 +1,9 @@
 ---
 title: Lidarr Reverse Proxy
-description: 
+description:
 published: true
 date: 2026-04-26T16:31:38.023Z
-tags: 
+tags:
 editor: markdown
 dateCreated: 2023-07-03T20:10:58.279Z
 ---

--- a/lidarr/plugins.md
+++ b/lidarr/plugins.md
@@ -192,3 +192,29 @@ TrevTV develops specialized Lidarr plugins for direct music platform integration
 
 > See the [Tubifarry README](https://github.com/TypNull/Tubifarry) for advanced configuration, troubleshooting, and feature deep-dives.
 {.is-info}
+
+## jtstothard/UniqueSingles
+
+[UniqueSingles by jtstothard](https://github.com/jtstothard/lidarr-plugin-uniquesingles)
+
+Removes duplicate singles when the same track already exists on a monitored album or EP. Matches by MusicBrainz recording ID, title + duration, or title alone.
+
+### Prerequisites
+
+- Lidarr nightly branch (plugins are not supported on stable)
+
+### Post-Install Configuration
+
+1. Go to **Settings → Connect** and select the **+** button
+2. Choose **Unique Singles** from the list
+3. Configure settings and select **Save**
+
+#### Settings
+
+- **Duration tolerance (ms):** how close track lengths need to be for a match (default 3000ms)
+- **Release types to compare:** which release types to check against singles (default: Album, EP)
+- **Title-only match action:** what happens when titles match but durations don't. Options: flag for review (default), skip, or auto-clean
+- **Scan interval (minutes):** how often to sweep the full library (default 1440 = 24 hours)
+
+> The scheduled scan appears under **Settings → Metadata** rather than Tasks. It's cosmetic and works fine.
+{.is-info}


### PR DESCRIPTION
Adds UniqueSingles by jtstothard to the Lidarr plugins page.

UniqueSingles removes duplicate singles when the same track already exists on a monitored album or EP. It matches by MusicBrainz recording ID, title + duration, or title alone, and runs on import and on a configurable scheduled interval.

Requires Lidarr nightly branch. Configured via Settings > Connect.