### PR TITLE
fix: Windows PowerShell snippet + install-script service-wait timeout

### DIFF
--- a/servarr/servarr-install-script.sh
+++ b/servarr/servarr-install-script.sh
@@ -360,8 +360,15 @@ echo ""
 echo "Checking if the service is up and running..."
 
 # Loop to wait until the service is active
+attempts=0
 while ! systemctl is-active --quiet "$app"; do
     sleep 1
+    attempts=$((attempts + 1))
+    if [ "$attempts" -gt 15 ]; then
+        echo ""
+        echo -e "${brown}[${app^}]${reset} service failed to start within 15 seconds. Check 'journalctl -u $app -e' for details."
+        exit 1
+    fi
 done
 
 echo ""

--- a/sonarr/tips-and-tricks.md
+++ b/sonarr/tips-and-tricks.md
@@ -55,8 +55,8 @@ find . -maxdepth 1 -type f \( -iname "*.mkv" -o -iname "*.mp4" \) -exec sh -c 'm
 Alternatively in Windows you can run the following script in Powershell to iterate over each file in a directory, and move it to a folder with the same name.
 
 ```powershell
-Get-ChildItem -File
-  | ForEach-Object {
+Get-ChildItem -File |
+  ForEach-Object {
     $dir = New-Item -ItemType Directory -Name $_.BaseName -Force
     $_ | Move-Item -Destination $dir
   }


### PR DESCRIPTION
## Summary

Two small, unrelated fixes split out of #466 so the grounding/security work can be reviewed on its own.

- Sonarr `tips-and-tricks.md`: the Windows PowerShell folder-creation snippet used a leading-pipe continuation, which is invalid in Windows PowerShell 5.1. Switched to a trailing pipe.
- `servarr/servarr-install-script.sh`: the post-install `systemctl is-active` wait loop had no exit, so a service that never starts (for example a missing libicu dependency) looped forever. Added a 15-attempt timeout that reports the failure and exits. Cherry-picked from #460.
